### PR TITLE
Use a common configuration for conversion scripts

### DIFF
--- a/generate_marcxml_with_auth_uris.sh
+++ b/generate_marcxml_with_auth_uris.sh
@@ -1,22 +1,33 @@
-#!/bin/ksh
+#!/bin/bash
 # process all files in the Marc dir and use Marc4J and SQL to look up authority keys
-# get the 92X URI and put it in the subfield 0. Finally send to /s/SUL/Dataload/LD4P/Marcxml - jkg
-#
-data=/s/SUL/Dataload/LD4P
-TBdir=/s/SUL/Bin/LD4P/TB1
+# get the 92X URI and put it in the subfield 0 - jkg
+
+# Check dependencies
+if [ "$LD4P_MARC" == "" ]; then
+    SCRIPT_PATH=$(dirname $0)
+    source ${SCRIPT_PATH}/ld4p_configure.sh
+fi
+
 stamp=`date "+%Y%m%d%H%s"`
+MRC_FILE="${LD4P_DATA}/marc.${stamp}"
+XML_FILE="${LD4P_MARCXML}/stf.${stamp}.xml"
 
 # Gather all the dumped marc records and make 1 temp file, then clean up.
-for F in `find $data/Marc -type f`
+echo "Searching for MARC files: ${LD4P_MARC}"
+for F_MRC in `find ${LD4P_MARC} -type f`
 do
-  cat $F >> $data/marc.$stamp
-
-  mv $F $data/Archive/Marc/.
+  cat $F_MRC >> ${MRC_FILE}
+  mv $F_MRC ${LD4P_DATA}/Archive/Marc/
 done
 
-# At present marc.$stamp is assumed to be one large file of marc records
-#
-/usr/bin/java -classpath $TBdir/lib/marc4j.jar:$TBdir/lib/ojdbc14.jar:$TBdir/classes/. MarcToXMLsf0 \
-              $data/marc.$stamp > $data/Marcxml/stf.$stamp.xml 2>> $data/log/errors
-
-[[ $? == 0 ]] && rm $data/marc.$stamp
+# $MRC_FILE is assumed to be one large file of marc records
+if [ -f ${MRC_FILE} ]; then
+    java -cp ${LD4P_JAR} org.stanford.MarcToXML ${MRC_FILE} > ${XML_FILE} 2>> ${LD4P_LOGS}/errors
+    conversion_success=$?
+    rm ${MRC_FILE}  # always cleanup the concatenation of all the marc files
+    if [ ${conversion_success} != 0 ]; then
+        echo "ERROR: Conversion failed" && cat ${LD4P_LOGS}/errors && exit 1
+    fi
+else
+    echo "WARNING: MARC files are missing" | tee --append ${LD4P_LOGS}/errors
+fi

--- a/ld4p_configure.sh
+++ b/ld4p_configure.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Configure the LD4P-tracer-bullet scripts
+#
+# This configuration script is designed to be used like so:
+# source ./ld4p_configure.sh
+#
+# If any custom LD4P_* paths are required, they can be set in the
+# system ENV or on the command line, like so:
+# LD4P_SIRSI=/ld4p_data LD4P_RDF=/ld4p_rdf source /path/to/ld4p_configure.sh
+
+export LD4P_BASEURI="http://linked-data-test.stanford.edu/library/"
+
+# If the system already defines an LD4P_SIRSI path, it will be used.
+# If a custom LD4P_SIRSI path is required, it can be set in the
+# system ENV or on the command line, like so:
+# LD4P_SIRSI=/ld4p_data source /path/to/ld4p_configure.sh
+if [ "$LD4P_SIRSI" == "" ]; then
+    export LD4P_SIRSI=/symphony
+fi
+if [ ! -d "$LD4P_SIRSI" ]; then
+    echo "ERROR: The LD4P scripts require an LD4P_SIRSI path: ${LD4P_SIRSI}" 1>&2
+    kill -INT $$
+else
+    echo "LD4P_SIRSI path: $LD4P_SIRSI"
+fi
+
+# If the system already defines an LD4P_RDF path, it will be used.
+# If a custom LD4P_RDF path is required, it can be set in the
+# system ENV or on the command line, like so:
+# LD4P_RDF=/ld4p_data source /path/to/ld4p_configure.sh
+if [ "$LD4P_RDF" == "" ]; then
+    export LD4P_RDF=/rdf
+fi
+if [ ! -d "$LD4P_RDF" ]; then
+    echo "ERROR: The LD4P scripts require an LD4P_RDF path: ${LD4P_RDF}" 1>&2
+    kill -INT $$
+else
+    echo "LD4P_RDF path:   $LD4P_RDF"
+fi
+
+export LD4P_BIN=${LD4P_SIRSI}/bin
+mkdir -p ${LD4P_BIN} || kill -INT $$
+
+# Java libraries should be installed or deployed from https://github.com/sul-dlss/ld4p-tracer-bullets
+# Check the deployment recipes in that project for details.
+export LD4P_JAR=${LD4P_BIN}/ld4p_converter.jar
+if [ ! -f "${LD4P_JAR}" ]; then
+   echo "ERROR: The LD4P scripts require a java library: ${LD4P_JAR}" 1>&2
+   echo "See https://github.com/sul-dlss/ld4p-tracer-bullets for details" 1>&2
+   kill -INT $$
+fi
+
+export LD4P_DATA=${LD4P_SIRSI}/Dataload/LD4P
+export LD4P_MARC=${LD4P_DATA}/Marc
+export LD4P_MARCXML=${LD4P_DATA}/MarcXML
+export LD4P_MARCRDF=${LD4P_RDF}/MarcRDF
+export LD4P_LOGS=${LD4P_DATA}/log
+
+mkdir -p ${LD4P_DATA} || kill -INT $$
+mkdir -p ${LD4P_MARC} || kill -INT $$
+mkdir -p ${LD4P_MARCXML} || kill -INT $$
+mkdir -p ${LD4P_MARCRDF} || kill -INT $$
+mkdir -p ${LD4P_DATA}/Archive/Marc || kill -INT $$
+mkdir -p ${LD4P_DATA}/Archive/MarcXML || kill -INT $$
+mkdir -p ${LD4P_LOGS} || kill -INT $$
+
+# Function wrapper to run a MARC to Bibframe converter, given an input and output file.
+# Usage:  ld4p_marc2bibframe {input_file} {output_file}
+ld4p_marc2bibframe () {
+    input_file=$1
+    output_file=$2
+    m2b_xquery=${LD4P_BIN}/Marc2Bibframe/marc2bibframe/xbin/saxon.xqy
+    /usr/bin/java -cp ${LD4P_JAR} net.sf.saxon.Query ${m2b_xquery} \
+                  baseuri=${LD4P_BASEURI} \
+                  serialization="rdfxml" \
+                  marcxmluri=${input_file} \
+                  1> ${output_file} \
+                  2>> ${LD4P_LOGS}/errors
+}
+

--- a/marcxml2bibframe.sh
+++ b/marcxml2bibframe.sh
@@ -1,20 +1,23 @@
-#!/bin/ksh
-# Run the LOC M2B converter here with STDOUT to RDF dir - jkg
-#
-data=/s/SUL/Dataload/LD4P
-m2b=/s/SUL/Bin/Marc2Bibframe/marc2bibframe
+#!/bin/bash
+# Run the converter
 
-for F in `find $data/Marcxml -type f`
+# Check dependencies
+if [ "$LD4P_MARCXML" == "" ]; then
+    SCRIPT_PATH=$(dirname $0)
+    source ${SCRIPT_PATH}/ld4p_configure.sh
+fi
+
+# Currently assumes there is one large MARC XML file in $LD4P_MARCXML path.
+echo "Searching for MARC XML files: ${LD4P_MARCXML}"
+for F_XML in `find ${LD4P_MARCXML} -type f`
 do
-  # convert to bibframe
-  # java -cp /path/to/saxon9he.jar net.sf.saxon.Query saxon.xqy \
-  # marcxmluri=/path/to/marc/xml/file baseuri=http://my-base-uri/ serialization=rdfxml
-
-  /usr/bin/java -classpath lib/saxon9he.jar net.sf.saxon.Query $m2b/xbin/saxon.xqy \
-                marcxmluri=$F baseuri="http://linked-data-test.stanford.edu/library/" \
-                serialization="rdfxml" 1>$data/RDF/stf.`date "+%Y%m%d%H%s"`.rdf 2>> $data/log/errors
-
-  echo "NO M2B CONVERSION ERRORS in $F.." >> $data/log/errors
-
-  mv $F $data/Archive/Marcxml/.
+    F_RDF="${LD4P_MARCRDF}/stf.`date "+%Y%m%d%H%s"`.rdf"
+    echo "Converting: ${F_XML} -> ${F_RDF}"
+    # See ld4p_configure.sh for details of ld4p_marc2bibframe
+    ld4p_marc2bibframe ${F_XML} ${F_RDF}
+    if [ $? == 0 ]; then
+      echo "INFO: Marc2Bibframe success for ${F_RDF}" >> ${LD4P_LOGS}/info
+      mv -p ${F_XML} ${LD4P_DATA}/Archive/MarcXML/
+    fi
 done
+


### PR DESCRIPTION
Fix #6 

A new configuration script is added for the LD4P conversion scripts:
- it uses environment variables to define data paths
- it checks conversion script dependencies
  - the java dependency is revised to use one JAR packaged from ld4p-tracer-bullets
  - this revised dependency is checked and used by the MarcToXML conversion
- it wraps the marc2bibframe conversion in a shell function
  - this function is declared in the configuration script
  - it can be modified when a different converter is required
  - it only requires two args, an input and output file path
