### PR TITLE
Add a git submodule to track the loc_marc2bibframe converter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "loc_marc2bibframe"]
+	path = loc_marc2bibframe
+	url = https://github.com/lcnetdev/marc2bibframe.git


### PR DESCRIPTION
```sh
$ git submodule add https://github.com/lcnetdev/marc2bibframe.git ./loc_marc2bibframe
```

This is the start of a solution for #10, which also requires some installation scripts.  This git submodule will allow this project to have easy access to the LOC converter and to track what version of it is used (the git submodule feature tracks a specific commit on the source project).

This might create a minor conflict with #18 in the .gitmodules file (or vice versa, depending on which PR is merged first).