### PR TITLE
git submodule for sul-dlss/ld4p-tracer-bullets

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ld4p_tracer_bullets"]
+	path = ld4p_tracer_bullets
+	url = https://github.com/sul-dlss/ld4p-tracer-bullets.git


### PR DESCRIPTION
Fix #17 

This might create a minor conflict with #12 in the `.gitmodules` file (or vice versa, depending on which PR is merged first).