### PR TITLE
ld4p_configure.sh - remove install script from config script

### DIFF
--- a/ld4p_configure.sh
+++ b/ld4p_configure.sh
@@ -64,9 +64,6 @@ mkdir -p ${LD4P_ARCHIVE_MARCRDF} || kill -INT $$
 mkdir -p ${LD4P_LOGS} || kill -INT $$
 mkdir -p ${LD4P_CONFIGS} || kill -INT $$
 
-# Check and install required libraries
-source ${SCRIPT_PATH}/ld4p_install_libraries.sh
-
 # Source bash functions to run converters
 source ${SCRIPT_PATH}/generate_marcxml_with_auth_uris.sh
 source ${SCRIPT_PATH}/loc_marc2bibframe.sh


### PR DESCRIPTION
Fix #25 

- separate the dependency installations from the routine configuration script
- dependency installation should be run once, not every time
