### PR TITLE
Scripts to load RDF into Blazegraph

### DIFF
--- a/blazegraph_load_api.sh
+++ b/blazegraph_load_api.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+if [ "$1" == "" -o "$1" == "-h" -o "$1" == "--help" ]; then
+    echo "Usage: $0 {file_or_directory} [{namespace}]"
+    exit
+else
+    FILE_OR_DIR=$1
+fi
+
+if [ ! -z "$2" ]; then
+    NAMESPACE=$2
+else
+    NAMESPACE=kb
+fi
+
+if [ -f "/etc/default/blazegraph" ] ; then
+    . "/etc/default/blazegraph" 
+else
+    JETTY_PORT=9999
+fi
+
+# Try to locate the RWStore.properties file using:
+# find /vagrant/downloads/BLAZEGRAPH_RELEASE_2_1_4 -name 'RWStore.properties'
+# The only result that seems to be an 'NSS' properties file is:
+# /vagrant/downloads/BLAZEGRAPH_RELEASE_2_1_4/src/resources/deployment/nss/WEB-INF/RWStore.properties
+#export NSS_DATALOAD_PROPERTIES=/usr/local/blazegraph/conf/RWStore.properties
+export NSS_DATALOAD_PROPERTIES=/vagrant/downloads/BLAZEGRAPH_RELEASE_2_1_4/src/resources/deployment/nss/WEB-INF/RWStore.properties
+
+#Probably some unused properties below, but copied all to be safe.
+LOAD_PROP_FILE=/tmp/$$.properties
+
+cat <<EOT >> $LOAD_PROP_FILE
+quiet=false
+verbose=0
+closure=false
+durableQueues=true
+
+com.bigdata.rdf.store.DataLoader.flush=false
+com.bigdata.rdf.store.DataLoader.bufferCapacity=100000
+com.bigdata.rdf.store.DataLoader.queueCapacity=10
+
+com.bigdata.rdf.store.DataLoader.ignoreInvalidFiles=true
+
+#Needed for quads
+#defaultGraph=
+
+#Namespace to load
+namespace=$NAMESPACE
+
+#Files to load
+fileOrDirs=$FILE_OR_DIR
+
+#Property file (if creating a new namespace)
+propertyFile=$NSS_DATALOAD_PROPERTIES
+EOT
+
+echo "Loading with properties..."
+cat $LOAD_PROP_FILE
+
+curl -X POST --data-binary @${LOAD_PROP_FILE} --header 'Content-Type:text/plain' http://localhost:${JETTY_PORT}/blazegraph/dataloader
+
+#Let the output go to STDOUT/ERR to allow script redirection
+
+rm -f $LOAD_PROP_FILE
+

--- a/blazegraph_load_rdf.sh
+++ b/blazegraph_load_rdf.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+if [ "$1" == '-h' -o "$1" == '--help' ]; then
+    cat <<HERE
+Usage:
+source ./ld4p_configure.sh # or custom config file
+$0 > log/blazegraph_load.log 2>&1
+
+ IMPORTANT:
+    - this script depends on ./lib/blazegraph_load_api.sh
+    - this script must be run on a system running blazegraph
+
+ TODO: try to generalize this script so it can accept config
+       params to setup the details in lib/blazegraph_load_api.sh 
+
+       Until the script is generalized for any blazegraph target, the
+       script assumes that the ./lib/blazegraph_load_api.sh script is
+       properly configured for the target blazegraph instance and this
+       script must be run on a system with blazegraph installed.
+
+ TODO: investigate optimal ways to load the triples into blazegraph.
+
+       At present, this script will iterate on the RDF files and submit them
+       to blazegraph one-by-one.  There could be better ways to load all the files,
+       depending on the performance of blazegraph.  Although it may not be the
+       greatest performance, loading them one-by-one has worked.
+HERE
+    exit
+fi
+
+
+# This install script depends on prior configuration
+if [ "$LD4P_MARCRDF" == "" ]; then
+    echo "LD4P_MARCRDF path is undefined."
+    echo "Please try again after 'source ld4p_configure.sh'"
+    exit 1
+fi
+
+
+echo "Blazegraph loading MARC-RDF files ${LD4P_MARCRDF}/*.rdf into 'ld4p' graph."
+find ${LD4P_MARCRDF} -type f -name '*.rdf' -exec ./blazegraph_load_api.sh {} ld4p \;
+


### PR DESCRIPTION
Fix #41 

These scripts were used to successfully load the Casalini RDF data into Blazegraph.  These scripts are an initial pass that works using the https://github.com/sul-dlss/blazegraph-vagrant to stand up a blazegraph triple store.  When there is a DLSS-VM running blazegraph, these scripts will be adapted to work with it (and probably refactored to generalize how they function so they might run on any blazegraph target; that generalization is premature at this stage).